### PR TITLE
be more specific with autopep8

### DIFF
--- a/epab/linters/_pep8.py
+++ b/epab/linters/_pep8.py
@@ -12,7 +12,8 @@ from epab.core import CONFIG, CTX
 @epab.utils.run_once
 @epab.utils.stashed
 def _pep8(amend: bool = False, stage: bool = False):
-    epab.utils.run(f'autopep8 -r --in-place --max-line-length {CONFIG.lint__line_length} .', mute=True)
+    epab.utils.run(f'autopep8 -r --in-place --max-line-length {CONFIG.lint__line_length} {CONFIG.package}', mute=True)
+    epab.utils.run(f'autopep8 -r --in-place --max-line-length {CONFIG.lint__line_length} test', mute=True)
     if amend:
         CTX.repo.amend_commit(append_to_msg='pep8 [auto]')
     elif stage:

--- a/test/test_cmd/test_linters.py
+++ b/test/test_cmd/test_linters.py
@@ -51,9 +51,11 @@ def test_lint_appveyor(amend_stage):
 
 
 def test_pep8():
-    with when(epab.utils).run(f'autopep8 -r --in-place --max-line-length {CONFIG.lint__line_length} .', mute=True):
-        _pep8._pep8()
-        verify(epab.utils).run(...)
+    when(epab.utils).run(
+        f'autopep8 -r --in-place --max-line-length {CONFIG.lint__line_length} {CONFIG.package}', mute=True)
+    when(epab.utils).run(f'autopep8 -r --in-place --max-line-length {CONFIG.lint__line_length} test', mute=True)
+    _pep8._pep8()
+    verifyStubbedInvocationsAreUsed()
 
 
 def test_pep8_amend():
@@ -64,11 +66,13 @@ def test_pep8_amend():
 
 
 def test_pep8_stage():
-    with when(epab.utils).run(f'autopep8 -r --in-place --max-line-length {CONFIG.lint__line_length} .', mute=True):
-        with when(CTX.repo).stage_all():
-            CTX.run_once = {}
-            _pep8._pep8(stage=True)
-            verify(CTX.repo).stage_all(...)
+    when(epab.utils).run(
+        f'autopep8 -r --in-place --max-line-length {CONFIG.lint__line_length} {CONFIG.package}', mute=True)
+    when(epab.utils).run(f'autopep8 -r --in-place --max-line-length {CONFIG.lint__line_length} test', mute=True)
+    with when(CTX.repo).stage_all():
+        CTX.run_once = {}
+        _pep8._pep8(stage=True)
+    verifyStubbedInvocationsAreUsed()
 
 
 def test_isort():


### PR DESCRIPTION
When he project folder is bloated (EDLM?), autopep8 takes ages
to parse through all the junk.

All we really want is to check:

  1. The package itself
  2. The tests